### PR TITLE
r111 will only keep AM on galaxy if it's greater than your free start…

### DIFF
--- a/javascripts/game/galaxy.js
+++ b/javascripts/game/galaxy.js
@@ -13,7 +13,7 @@ function galaxyReset(bulk) {
 
 	let am = player.money
 	doReset("gal")
-	if (hasAch("r111")) player.money = am
+	if (hasAch("r111") && am.gte(player.money)) player.money = am
 }
 
 function checkOnGalaxyReset() {

--- a/javascripts/mods/ngud/update.js
+++ b/javascripts/mods/ngud/update.js
@@ -154,7 +154,7 @@ function updateBHFeed() {
 
 	if (mod.udsp) {
 		let gain = Math.floor(Math.min(player.blackhole.hunger, player.blackhole.upgrades.total / 3))
-		el("feedBHButton").className = gain == 1 ? "eternityupbtn" : "eternityupbtnlocked"
+		el("feedBHButton").className = gain >= 1 ? "eternityupbtn" : "eternityupbtnlocked"
 	}
 }
 


### PR DESCRIPTION
…ing amount

this fixes an issue where if you big crunch then start getting replicanti galaxies very fast without having ngpp16, your antimatter will gradually decrease until it's less than 100, and you will have to manually buy a single 1st dimension to "kick start" production again. Besides, the "start with x antimatter" achievements should serve as minimums, and an achievement reward shouldn't give you anything less than the minimum