### PR TITLE
fixed charging for already bought dilation upgrades

### DIFF
--- a/javascripts/eter/dilation.js
+++ b/javascripts/eter/dilation.js
@@ -308,7 +308,6 @@ function getRebuyableDilUpgScaleStart(id, add=0) {
 function buyDilationUpgrade(id, max) {
 	let cost = getDilUpgCost(id)
 	if (!player.dilation.dilatedTime.gte(cost)) return
-	player.dilation.dilatedTime = player.dilation.dilatedTime.sub(cost)
 
 	if (id[0] == "r") {
 		// Rebuyable
@@ -321,7 +320,8 @@ function buyDilationUpgrade(id, max) {
 		if (id == 2) {
 			if (speedrunMilestonesReached < 22) player.dilation.dilatedTime = E(0)
 			resetDilationGalaxies()
-		}
+		} else player.dilation.dilatedTime = player.dilation.dilatedTime.sub(cost)
+		
 		if (id >= 3) player.eternityBuyer.tpUpgraded = true
 	} else {
 		// Not rebuyable


### PR DESCRIPTION
The buy dilation upgrade function would subtract the cost before checking if you already had the upgrade, so the NGUdS autobuyer could get stuck in an endless loop of "buying" the same non-rebuyable upgrade over and over again, and clicking on an already bought upgrade would charge for it again. This also caused non-rebuyable upgrades to be charged for twice when bought normally. moving the subtraction after the upgrade code fixes both issues.