### PR TITLE
achievement ngpp13 properly enables dilation upgrade autobuyer in NGUdS

### DIFF
--- a/javascripts/game.js
+++ b/javascripts/game.js
@@ -1466,7 +1466,7 @@ function notifyGhostifyMilestones(){
 
 function dilationStuffABTick(){
 	el('rebuyupgAuto').style.display = speedrunMilestonesReached>6?"":"none"
-	el('dilUpgsAuto').style.display = hasAch("ngud14") && mod.udsp ? "" : "none"
+	el('dilUpgsAuto').style.display = hasAch("ngpp13") && mod.udsp ? "" : "none"
 	el('distribEx').style.display = hasAch("ngud14") ? "" : "none"
 	if (player?.autoEterOptions?.dilUpgs) autoBuyDilUpgs()
 


### PR DESCRIPTION
it was originally unlocked by ngud14 ("finally i'm out of that channel") but i'm assuming it was intended to be unlocked by ngpp13 ("in the grim darkness of a far endgame") because the game specifically checks for mod.udsp to be enabled before adding "and you can auto-buy dilation upgrades" to the tooltip