### PR TITLE
Add toggle of tab title antimatter display

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,6 +225,8 @@
 						<td><button onclick="showOptions('notationmenu')" id="notation" onclick="" class="storebtn" style="color:black; width: 200px; height: 55px; font-size:10px"></button></td>
 						<td><button onclick="showVisibilityMenu()" class="storebtn" style="color:black; width: 200px; height: 55px; font-size: 15px">Show/hide stuff</button></td>
 						<td><button id="netQuarkTop" onclick="updateNetTop(true)" class="storebtn" style="color:black; width: 200px; height: 55px; font-size: 15px"></button></td>
+					</tr><tr>
+						<td><button id="tabAmount" onclick="toggleTabAmount()" class="storebtn" style="color:black; width: 200px; height: 55px; font-size:120%"></button></td>
 					</tr>
 				</table>
 			</div>

--- a/javascripts/core/load_functions.js
+++ b/javascripts/core/load_functions.js
@@ -1520,6 +1520,8 @@ function onLoad(noOffline) {
 
 	tmp.tickUpdate = true
 	updateCheckBoxes()
+	toggleTabAmount()
+	toggleTabAmount()
 	toggleChallengeRetry()
 	toggleChallengeRetry()
 	toggleBulk()

--- a/javascripts/core/saving.js
+++ b/javascripts/core/saving.js
@@ -599,6 +599,7 @@ function updateNewPlayer(mode, preset) {
 			eternityconfirm: true,
 			commas: "Commas",
 			updateRate: 50,
+			tabAmount: true,
 			animations: {
 				floatingText: true,
 				bigCrunch: true,

--- a/javascripts/game.js
+++ b/javascripts/game.js
@@ -184,7 +184,8 @@ el("theme").onclick = function () {
 
 function updateMoney() {
 	let abbs = modAbbs(mod, true)
-	el("z").textContent = (abbs.length > 8 ? "" : "AD: ") + abbs + " | " + shortenMoney(player.money) + (player.money.e >= 1e6 ? "" : " antimatter")
+	if (player.options.tabAmount)
+		el("z").textContent = (abbs.length > 8 ? "" : "AD: ") + abbs + " | " + shortenMoney(player.money) + (player.money.e >= 1e6 ? "" : " antimatter")
 	el("coinAmount").textContent = formatQuick(player.money, 2, inNGM(3) ? Math.min(Math.max(3 - player.money.e, 0), 3) : 0)
 
 	var element2 = el("matter");
@@ -293,6 +294,13 @@ function updateEternityChallenges() {
 function toggleChallengeRetry() {
 	player.options.retryChallenge = !player.options.retryChallenge
 	el("retry").textContent = "Automatically retry challenges: O" + (player.options.retryChallenge ? "N" : "FF")
+}
+
+function toggleTabAmount() {
+	player.options.tabAmount = !player.options.tabAmount
+	el("tabAmount").textContent = "Show Antimatter amount in tab title: O" + (player.options.tabAmount ? "N" : "FF")
+	let abbs = modAbbs(mod, true)
+	if (!player.options.tabAmount) el("z").textContent = (abbs.length > 8 ? "" : "AD: ") + abbs
 }
 
 el("news").onclick = function () {


### PR DESCRIPTION
Introduces a user preference to show or hide the amount of antimatter in the browser tab title. Added a button in display options to toggle that preference.