### PR TITLE
Add missing big crunch condition

### DIFF
--- a/javascripts/inf/infinity.js
+++ b/javascripts/inf/infinity.js
@@ -1,5 +1,17 @@
 var isEmptiness=false
+
+function canBigCrunch() {
+	return (
+		!player.currentChallenge.startsWith("post") &&
+		player.money.gte(Number.MAX_VALUE)
+	) || (
+		player.currentChallenge !== "" &&
+		player.money.gte(player.challengeTarget)
+	)
+}
+
 function bigCrunch(auto) {
+	if (!canBigCrunch()) return
 	if (implosionCheck) return
 
 	if (!auto && player.options.animations.bigCrunch) {


### PR DESCRIPTION
This fixes an issue introduced in f20c65e07aa8085e1d56c5f2c92da369bcd2f861
In that commit, the condition that was checking if player can big crunch was removed.
The condition was located in line 1852 of the file game.js. [Link to line in previous commit](https://github.com/aarextiaokhiao/NG-plus-3/blob/c9f19e52601c5790fcce7215a794578b2898fa0e/javascripts/game.js#L1852)
That allowed to big crunch even when it should not be allowed using keyboard shortcut, and ruin pre-infinity game experience in Grand Runs, NG= or NG- runs.