### PR TITLE
NG-4 and timeDim cost handling fixes/enhancements

### DIFF
--- a/javascripts/core/load_functions.js
+++ b/javascripts/core/load_functions.js
@@ -1701,7 +1701,7 @@ function conToDeciTD(){
 	for (let dim = 1; dim <= 8; dim++) {
 		const data = player["timeDimension"+dim]
 		data.amount = E(data.amount)
-		data.cost = isNaN(data.cost) ? timeDimCost(dim, data.bought) : E(data.cost)
+		data.cost = isNaN(E(data.cost).e) ? timeDimCost(dim, data.bought) : E(data.cost)
 		data.power = E(data.power)
 	}
 }

--- a/javascripts/core/load_functions.js
+++ b/javascripts/core/load_functions.js
@@ -553,7 +553,7 @@ function doNGP2v2tov2302(){
 	if (aarMod.newGamePlusPlusVersion < 2) {
 		for (dim=1;dim<5;dim++) {
 			var dim = player["timeDimension" + dim]
-			if (Decimal.gte(dim.cost, "1e20000")) dim.cost = E_pow(timeDimCostMults[dim]*2.2, dim.bought).mul(timeDimStartCosts[dim]).mul(E_pow(E('1e1000'),Math.pow(dim.cost.log(10) / 1000 - 20, 2)))
+			if (Decimal.gte(dim.cost, "1e20000")) dim.cost = E_pow(getTimeDimCostMult(dim)*2.2, dim.bought).mul(getTimeDimStartCost(dim)).mul(E_pow(E('1e1000'),Math.pow(dim.cost.log(10) / 1000 - 20, 2)))
 		}
 		player.meta = {resets: 0, antimatter: 10, bestAntimatter: 10}
 		for (dim=1;dim<9;dim++) player.meta[dim] = {amount: 0, bought: 0, cost: initCost[dim]}
@@ -561,7 +561,7 @@ function doNGP2v2tov2302(){
 	if (aarMod.newGamePlusPlusVersion < 2.2) {
 		for (dim=1;dim<5;dim++) {
 			var dim = player["timeDimension" + dim]
-			if (Decimal.gte(dim.cost, "1e100000")) dim.cost = E_pow(timeDimCostMults[dim]*100, dim.bought).mul(timeDimStartCosts[dim]).mul(E_pow(E('1e1000'),Math.pow(dim.cost.log(10) / 1000 - 100, 2)))
+			if (Decimal.gte(dim.cost, "1e100000")) dim.cost = E_pow(getTimeDimCostMult(dim)*100, dim.bought).mul(getTimeDimStartCost(dim)).mul(E_pow(E('1e1000'),Math.pow(dim.cost.log(10) / 1000 - 100, 2)))
 		}
 		
 		player.autoEterMode == "amount"
@@ -1199,7 +1199,7 @@ function dov12tov122(){
 	if (player.version < 12) {
 		for (i=1; i<5; i++) {
 			if (player["timeDimension"+i].cost.gte("1e1300")) {
-				player["timeDimension"+i].cost = E_pow(timeDimCostMults[i]*2.2, player["timeDimension"+i].bought).mul(timeDimStartCosts[i])
+				player["timeDimension"+i].cost = E_pow(getTimeDimCostMult(i)*2.2, player["timeDimension"+i].bought).mul(getTimeDimStartCost(i))
 			}
 		}
 		if (player.bestEternity <= 0.01 || player.bestInfinityTime <= 0.01) giveAchievement("Less than or equal to 0.001");

--- a/javascripts/core/load_functions.js
+++ b/javascripts/core/load_functions.js
@@ -1701,7 +1701,7 @@ function conToDeciTD(){
 	for (let dim = 1; dim <= 8; dim++) {
 		const data = player["timeDimension"+dim]
 		data.amount = E(data.amount)
-		data.cost = isNaN(data.cost.e) ? timeDimCost(dim, data.bought) : E(data.cost)
+		data.cost = isNaN(data.cost) ? timeDimCost(dim, data.bought) : E(data.cost)
 		data.power = E(data.power)
 	}
 }

--- a/javascripts/eter/time_dimension.js
+++ b/javascripts/eter/time_dimension.js
@@ -160,12 +160,20 @@ function updateTimeShards() {
 var timeDimCostMults = [[null, 3, 9, 27, 81, 243, 729, 2187, 6561], [null, 1.5, 2, 3, 20, 150, 1e5, 3e6, 1e8]]
 var timeDimStartCosts = [[null, 1, 5, 100, 1000, "1e2350", "1e2650", "1e3000", "1e3350"], [null, 10, 20, 40, 80, 160, 1e8, 1e12, 1e18]]
 
+function getTimeDimCostMult(tier) {
+	return inNGM(4) ? timeDimCostMults[1][tier] : timeDimCostMults[0][tier]
+}
+
+function getTimeDimStartCost(tier) {
+	return inNGM(4) ? timeDimStartCosts[1][tier] : timeDimStartCosts[0][tier]
+}
+
 function timeDimCost(tier, bought) {
-	var cost = E_pow(timeDimCostMults[0][tier], bought).mul(timeDimStartCosts[0][tier])
+	var cost = E_pow(getTimeDimCostMult(tier), bought).mul(getTimeDimStartCost(tier))
 	if (inNGM(2)) return cost
-	if (cost.gte(Number.MAX_VALUE)) cost = E_pow(timeDimCostMults[0][tier]*1.5, bought).mul(timeDimStartCosts[0][tier])
-	if (cost.gte("1e1300")) cost = E_pow(timeDimCostMults[0][tier]*2.2, bought).mul(timeDimStartCosts[0][tier])
-	if (tier > 4) cost = E_pow(timeDimCostMults[0][tier]*100, bought).mul(timeDimStartCosts[0][tier])
+	if (cost.gte(Number.MAX_VALUE)) cost = E_pow(getTimeDimCostMult(tier)*1.5, bought).mul(getTimeDimStartCost(tier))
+	if (cost.gte("1e1300")) cost = E_pow(getTimeDimCostMult(tier)*2.2, bought).mul(getTimeDimStartCost(tier))
+	if (tier > 4) cost = E_pow(getTimeDimCostMult(tier)*100, bought).mul(getTimeDimStartCost(tier))
 	if (cost.gte(tier > 4 ? "1e300000" : "1e20000")) {
 		// rather than fixed cost scaling as before, quadratic cost scaling
 		// to avoid exponential growth

--- a/javascripts/eter/time_dimension.js
+++ b/javascripts/eter/time_dimension.js
@@ -196,12 +196,11 @@ function buyTimeDimension(tier, am) {
 	dim.amount = dim.amount.add(1);
 	dim.bought += 1
 	if (inNGM(4)) {
-		dim.cost = dim.cost.mul(timeDimCostMults[1][tier])
 		if (inNC(2) || player.currentChallenge == "postc1") player.chall2Pow = 0
 	} else {
 		dim.power = dim.power.mul(mod.rs ? 3 : 2)
-		dim.cost = timeDimCost(tier, dim.bought)
 	}
+	dim.cost = timeDimCost(tier, dim.bought)
 	return true
 }
 
@@ -264,11 +263,10 @@ function buyMaxTimeDimension(tier, bulk) {
 	dim.bought += toBuy
 	if (inNGM(4)) {
 		dim.power = E(getDimensionPowerMultiplier()).sqrt().mul(dim.power)
-		dim.cost = dim.cost.mul(E_pow(timeDimCostMults[1][tier], toBuy))
 	} else {
-		dim.cost = timeDimCost(tier, dim.bought)
 		dim.power = dim.power.mul(E_pow(mod.rs ? 3 : 2, toBuy))
 	}
+	dim.cost = timeDimCost(tier, dim.bought)
 }
 
 function buyMaxTimeDimensions() {

--- a/javascripts/mods/ngmm/ngm4.js
+++ b/javascripts/mods/ngmm/ngm4.js
@@ -23,7 +23,7 @@ function resetNGM4TDs() {
 	completelyResetTimeDimensions()
 	for (var d = 1; d <= 8; d++) {
 		var dim = player["timeDimension" + d]
-		dim.cost = E(timeDimStartCosts[1][d])
+		dim.cost = E(getTimeDimStartCost(d))
 		dim.power = E(power).pow((player.tdBoosts - d + 1) / 2).max(1)
 	}
 	player.timeShards = E(0)


### PR DESCRIPTION
These commits fix:
- Wrong time dimension costs when loading NG-4
- Not proprerly reading time dimensions cost upon load from save (bug introduced in 9b8f053d6eeb3a787494cde3a649790141651573)
- `timeDimCost` not returning cost based on mode (NG-4 vs other)

Added:
- Functions to access TimeDim StartCost and CostMult based on mod loaded,
  and replaced direct array accesses (where possible) to those functions through the codebase

