### PR TITLE
Reset Infinity Dimension amount to amount of bought on infinity reset.

### DIFF
--- a/javascripts/core/resets.js
+++ b/javascripts/core/resets.js
@@ -108,6 +108,7 @@ let RESETS = {
 
 			if (inNGM(2)) player.galacticSacrifice = newGalacticDataOnInfinity(order != "inf")
 			player.infinityPower = E(1)
+			resetInfinityDimensionsAmount()
 
 			let keepRep = hasAch("r95")
 			if (!keepRep) player.replicanti.amount = E(1)
@@ -535,6 +536,13 @@ function nanofieldResetOnQuantum(){
 	nfSave.antienergy = E(0)
 	nfSave.power = 0
 	nfSave.powerThreshold = E(50)
+}
+
+function resetInfinityDimensionsAmount() {
+	for (let i = 1; i <= 8; i++) {
+		const dim = player["infinityDimension" + 1]
+		dim.amount = E(dim.baseAmount)
+	}
 }
 
 function completelyResetInfinityDimensions() {


### PR DESCRIPTION
This change ensures proper handling of infinity dimension amounts during infinity resets, as it is in vanilla AD. ([source](https://antimatter-dimensions.fandom.com/wiki/Infinity_Dimensions?so=search#:~:text=They%20will%20be%20reset%20to%20their%20bought%20amounts%20upon%20Big%20Crunch.))

The change makes the game harder in area between unlocking infinity dimensions and eternity